### PR TITLE
Silent mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,23 @@
-
 include config.mk
 
-CC=gcc
-LD=gcc
-CFLAGS=-g -Wall -DVERSION=\"${VERSION}\" `pkg-config --cflags xft`
-OBJ=mmkeyosd.o config.o
-LIBS=-lX11 `pkg-config --libs xft` -lXinerama
+CC ?= gcc
+LD ?= gcc
+CFLAGS += -Wall
+VERSION_SYM = -DVERSION=\"${VERSION}\"
+XFT_INC = $(shell pkg-config --cflags xft)
+XFT_LIB = $(shell pkg-config --libs xft)
+OBJ = mmkeyosd.o config.o
+LIBS = -lX11 $(XFT_LIB) -lXinerama
 
 all: mmkeyosd
 
 mmkeyosd: $(OBJ)
 	@echo LD -o $@
-	@$(LD) $(LDFLAGS) $(OBJ) $(LIBS) -o $@
+	@$(CC) $(LDFLAGS) $(OBJ) $(LIBS) -o $@
 
 %.o: %.c
 	@echo CC $<
-	@$(CC) $(CFLAGS) -c $< -o $@
+	@$(CC) $(CFLAGS) $(VERSION_SYM) $(XFT_INC) -c $< -o $@
 
 ${OBJ}: config.h config.mk
 
@@ -26,7 +28,5 @@ install: mmkeyosd
 	@mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	@install -m644 mmkeyosd.1 $(DESTDIR)$(MANPREFIX)/man1/
 
-
 clean:
 	rm -f $(OBJ) mmkeyosd
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Configuration
 Keys are configured in ~/.mmkeyosd/keys. The syntax is easy; each line 
 is a keybinding. First field specifies which keys to use. Syntax of key field is:
 
-	[Any of Super, Alt, Control+]Key
+	[Any of Super, Alt, Shift, Control+]Key
 	ControlAlt+m
 	AudioRaiseVolume
 
@@ -48,6 +48,14 @@ Possible settings are:
 
 Everything else, empty lines and lines starting with `#` are ignored.
 See keys.example and settings.example for more info.
+
+Silent mode
+-----------
+
+When in silent mode, mmkeyosd will react to input and execute the configured
+commands but won't show the OSD window.
+
+To activate silent mode send SIGUSR1, to stop it send SIGUSR2 to the process.
 
 Thanks to
 ---------

--- a/config.c
+++ b/config.c
@@ -25,6 +25,7 @@ modtable[] = {
 	{"Control",       ControlMask},
 	{"Super",         Mod4Mask},
 	{"Alt",           Mod1Mask},
+	{"Shift",         ShiftMask},
 };
 
 /* some dynamic string macros */

--- a/config.mk
+++ b/config.mk
@@ -1,6 +1,4 @@
-
-VERSION=1.0
+VERSION=1.1
 PREFIX?=/usr/local
 DESTDIR?=
 MANPREFIX=$(PREFIX)/share/man
-


### PR DESCRIPTION
Dunst has a feature whereupon recieving a SIGUSR1 signal it stops displaying notifications and does so until recieving a SIGUSR2 signal.
This PR implements such a feature in mmkeyosd, so users can toggle displaying the OSD when not desired but still want the commands to be executed.
I also added Shift as a possible modifier key since I needed it.
